### PR TITLE
Allow providing right hand side of confirm key mapping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ let g:completion_confirm_key = "\<C-y>"
 ```
 - Make sure to use `" "` and add escape key `\` to avoid parsing issue.
 
+- If confirm key has a fallback mapping, for example, if you use auto pairs plugin that maps to `<CR>`, provide it like this:
+```.vim
+"Fallback for https://github.com/Raimondi/delimitMate expanding on enter
+let g:completion_confirm_key_rhs = "\<Plug>delimitMateCR"
+```
+
 ### Enable/Disable auto hover
 - By default when navigate through complete items, LSP's hover is automatically
 called and display in floating window, disable it by

--- a/autoload/completion.vim
+++ b/autoload/completion.vim
@@ -7,7 +7,14 @@ function! completion#wrap_completion() abort
     if pumvisible() != 0
         lua require'completion'.confirmCompletion()
     else
-        call nvim_feedkeys(g:completion_confirm_key, 'n', v:true)
+        let key = g:completion_confirm_key
+        let remap = 'n'
+        if !empty(g:completion_confirm_key_rhs)
+            let key = g:completion_confirm_key_rhs
+            let remap = 'm'
+        endif
+
+        call nvim_feedkeys(key, remap, v:true)
     endif
 endfunction
 

--- a/plugin/completion.vim
+++ b/plugin/completion.vim
@@ -15,6 +15,10 @@ if ! exists('g:completion_confirm_key')
     let g:completion_confirm_key = "\<CR>"
 endif
 
+if ! exists('g:completion_confirm_key_rhs')
+    let g:completion_confirm_key_rhs = ''
+endif
+
 if ! exists('g:completion_enable_auto_hover')
     let g:completion_enable_auto_hover = 1
 endif


### PR DESCRIPTION
Hi,

first of all, great plugin! I'm finally able to ditch coc.

I found one issue with confirm key. It overrides the mapping completely.
In cases where confirm key is also used for something else, like for example `<CR>` for auto pairs plugin to expand on enter, it stops expanding after setting  completion. I know I can map it to something else, but i think it's neat to have Enter available for both.
For cases like this, I introduced new variable that will be used as fallback in these situations. 