### PR TITLE
Fuzzy matching in completion items

### DIFF
--- a/lua/source.lua
+++ b/lua/source.lua
@@ -44,7 +44,7 @@ function M.triggerCurrentCompletion(manager, bufnr, prefix, textMatch)
     else
       items = {}
       for _, func in ipairs(complete_source.trigger_function) do
-        item = func(prefix, bufnr)
+        item = func(prefix, util.fuzzy_score, bufnr)
         vim.list_extend(items, item)
       end
       util.sort_completion_items(items)

--- a/lua/source/lsp.lua
+++ b/lua/source/lsp.lua
@@ -5,7 +5,7 @@ local snippet = require 'source.snippet'
 local M = {}
 
 
-M.getCompletionItems = function(prefix, bufnr)
+M.getCompletionItems = function(prefix, _, bufnr)
   local items = {}
   -- M.callback_complete = false
   local params = vim.lsp.util.make_position_params()

--- a/lua/source/snippet.lua
+++ b/lua/source/snippet.lua
@@ -4,7 +4,7 @@ local util = require 'utility'
 local M = {}
 
 
-local getUltisnipItems = function(prefix)
+local getUltisnipItems = function(prefix, score_func)
   snippetsList = api.nvim_call_function('UltiSnips#SnippetsInCurrentScope', {})
   local complete_items = {}
   if vim.tbl_isempty(snippetsList) then
@@ -15,7 +15,8 @@ local getUltisnipItems = function(prefix)
     if key == true then
       key = 'true'
     end
-    if string.sub(key, 1, #prefix) == prefix then
+	local score = score_func(prefix, key)
+    if score < #prefix then
       table.insert(complete_items, {
         word = key,
         kind = 'UltiSnips',
@@ -28,7 +29,7 @@ local getUltisnipItems = function(prefix)
   return complete_items
 end
 
-local getNeosnippetItems = function(prefix)
+local getNeosnippetItems = function(prefix, score_func)
   snippetsList = api.nvim_call_function('neosnippet#helpers#get_completion_snippets', {})
   local complete_items = {}
   if vim.tbl_isempty(snippetsList) == 0 then
@@ -38,10 +39,12 @@ local getNeosnippetItems = function(prefix)
     if key == true then
       key = 'true'
     end
-    if string.sub(key, 1, #prefix) == prefix then
+	local score = score_func(prefix, key)
+    if score < #prefix then
       table.insert(complete_items, {
         word = key,
         kind = 'Neosnippet',
+		score = score,
         icase = 1,
         dup = 1,
         empty = 1,
@@ -51,13 +54,13 @@ local getNeosnippetItems = function(prefix)
   return complete_items
 end
 
-M.getCompletionItems = function(prefix)
+M.getCompletionItems = function(prefix, score_func, _)
   local source = api.nvim_get_var('completion_enable_snippet')
   local snippet_list = {}
   if source == 'UltiSnips' then
-    snippet_list = getUltisnipItems(prefix)
+    snippet_list = getUltisnipItems(prefix, score_func)
   elseif source == 'Neosnippet' then
-    snippet_list = getNeosnippetItems(prefix)
+    snippet_list = getNeosnippetItems(prefix, score_func)
   end
   return snippet_list
 end

--- a/lua/source/ts_complete.lua
+++ b/lua/source/ts_complete.lua
@@ -54,7 +54,8 @@ local function smallestContext(tree, parser, source)
 	return current
 end
 
-local function getCompletionItems(parser, prefix)
+function M.getCompletionItems(prefix, score_func, bufnr)
+	local parser = ts.get_parser(bufnr)
 	local tstree = parser:parse():root()
 
 	-- Get all identifiers
@@ -86,12 +87,14 @@ local function getCompletionItems(parser, prefix)
 		local node_text = get_node_text(node)
 
 		-- Only consider items in current scope, and not already met
-		if node_text:sub(1, #prefix) == prefix 
+		local score = score_func(prefix, node_text)
+		if score < #prefix
 			and (is_parent(node, context_here) or smallestContext(tstree, parser, node) == nil or name == "func")
 			and not vim.tbl_contains(found, node_text) then
 			table.insert(complete_items, {
 				word = node_text,
 				kind = 'TS : '..name,
+				score = score,
 				icase = 1,
 				dup = 1,
 				empty = 1,

--- a/lua/utility.lua
+++ b/lua/utility.lua
@@ -19,7 +19,7 @@ local function remove_unmatch_completion_items(items, prefix)
 end
 
 function M.sort_completion_items(items)
-  table.sort(items, function(a, b) return string.len(a.word) < string.len(b.word)
+  table.sort(items, function(a, b) return (a.score or string.len(a.word)) < (b.score or string.len(a.word))
   end)
 end
 
@@ -66,7 +66,48 @@ function M.text_document_completion_list_to_complete_items(result, prefix)
   return matches
 end
 
+-- Levenshtein algorithm for fuzzy matching
+-- https://gist.github.com/james2doyle/e406180e143da3bdd102
+function M.fuzzy_score(str1, str2)
+  local len1 = #str1
+  local len2 = #str2
+  local matrix = {}
+  local cost = 1
+  local min = math.min;
 
+  -- quick cut-offs to save time
+  if (len1 == 0) then
+    return len2
+  elseif (len2 == 0) then
+    return len1
+  elseif (str1 == str2) then
+    return 0
+  end
+
+  -- initialise the base matrix values
+  for i = 0, len1, 1 do
+    matrix[i] = {}
+    matrix[i][0] = i
+  end
+  for j = 0, len2, 1 do
+    matrix[0][j] = j
+  end
+
+  -- actual Levenshtein algorithm
+  for i = 1, len1, 1 do
+    for j = 1, len2, 1 do
+      if (str1:byte(i) == str2:byte(j)) then
+        cost = 0
+	else
+		cost=1
+      end
+      matrix[i][j] = min(matrix[i-1][j] + 2, matrix[i][j-1], matrix[i-1][j-1] + cost)
+    end
+  end
+
+  -- return the last value - this is the Levenshtein distance
+  return matrix[len1][len2]
+end
 
 
 ---------------------------------


### PR DESCRIPTION
This PR allow fuzzy matching of completion items (for non `ins-complete` sources).
It uses a modified version of the Levenshtein distance, so that it is nearly non fuzzy but also suggests some items that are not exactly matching the current word.

Performance is not impacted at all in the tests I've done.