### PR TITLE
Add detail to the snippet completion items

### DIFF
--- a/lua/source/snippet.lua
+++ b/lua/source/snippet.lua
@@ -21,6 +21,7 @@ local getUltisnipItems = function(prefix, score_func)
       table.insert(complete_items, {
         word = key,
         kind = 'UltiSnips',
+        menu = val,
         score = score,
         icase = 1,
         dup = 1,
@@ -48,6 +49,7 @@ local getNeosnippetItems = function(prefix, score_func)
         table.insert(complete_items, {
           word = key,
           kind = 'Neosnippet',
+          menu = val.description,
           score = score,
           icase = 1,
           dup = 1,


### PR DESCRIPTION
Use the menu to add further details for any snippet completions, to help the user pick the right one without guessing.