### PR TITLE
fixed leaking augroup

### DIFF
--- a/lua/completion.lua
+++ b/lua/completion.lua
@@ -285,6 +285,7 @@ end
 M.on_attach = function()
   hover.modifyCallback()
   api.nvim_command [[augroup CompletionCommand]]
+    api.nvim_command("autocmd!")
     api.nvim_command("autocmd InsertEnter <buffer> lua require'completion'.on_InsertEnter()")
     api.nvim_command("autocmd InsertLeave <buffer> lua require'completion'.on_InsertLeave()")
     api.nvim_command("autocmd InsertCharPre <buffer> lua require'completion'.on_InsertCharPre()")


### PR DESCRIPTION
The created group `CompletionCommand` leaks the autocommands. 
Calling `autocmd!` clears the current group when the plugin gets attached.

Without clearing the group there are multiple autocmds fors the same action present. 