### PR TITLE
refactor: replace goto for Lua 5.1 compatibility

### DIFF
--- a/lua/completion/complete.lua
+++ b/lua/completion/complete.lua
@@ -36,17 +36,15 @@ M.performComplete = function(complete_source, complete_items_map, manager, bufnr
     -- collect getCompleteItems function of current completion source
     for _, item in ipairs(complete_source.complete_items) do
       local complete_items = complete_items_map[item]
-      if complete_items == nil then
-        goto continue
+      if complete_items ~= nil then
+        if complete_items.callback == nil then
+          table.insert(callback_array, true)
+        else
+          table.insert(callback_array, complete_items.callback)
+          complete_items.trigger(prefix, textMatch, bufnr, manager)
+        end
+        table.insert(items_array, complete_items.item)
       end
-      if complete_items.callback == nil then
-        table.insert(callback_array, true)
-      else
-        table.insert(callback_array, complete_items.callback)
-        complete_items.trigger(prefix, textMatch, bufnr, manager)
-      end
-      table.insert(items_array, complete_items.item)
-      ::continue::
     end
 
     local timer = vim.loop.new_timer()


### PR DESCRIPTION
👋 I tried out this plugin with Neovim nightly via the unstable PPA on a clean install of Ubuntu 20.04, and I got the following error on when I run `lua require'completion'.on_attach()`:

```
E5108: Error executing lua error loading module 'completion.complete' from file 'completion-nvim/lua/completion/complete.lua':
completion-nvim/lua/completion/complete.lua:40: '=' expected near 'continue'
```

It turns out that the unstable PPA version of `nvim` is linked against Lua 5.1 (`:lua print(_VERSION)`), which does not have support for `goto`. This pull request refactors that part of the code so that it shouldn't need a `goto`. Please let me know if there are further adjustments I need to make (or feel free to do them yourself in the interest of speed).