### PR TITLE
Correct docs and readme typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,13 @@ let g:completion_timer_cycle = 200 "default value is 80
 
 ## Compatibility with diagnostic-nvim
 
-- This plugin only focus on the **completion** part of the built-in LSP. If you want setup in the diagnostic part
-(e.g. virtual text, jump through diagnostic, open line diagnostic automatically...), take a loot at [diagnostic-nvim]
-(https://github.com/haorenW1025/diagnostic-nvim).
+- This plugin only focuses on the **completion** part of the built-in LSP. If
+  you want similar help with diagnostics (e.g. virtual text, jump to diagnostic,
+  open line diagnostic automatically...), take a loot at [diagnostic-nvim]
+  (https://github.com/haorenW1025/diagnostic-nvim).
 
-- Both diagnostic-nvim and completion-nvim require setting up via `on_attach`. To use them together, create a wrapper
-function like this.
+- Both diagnostic-nvim and completion-nvim require setting up via `on_attach`.
+  To use them together, create a wrapper function like this.
 
 ```vim
 lua << EOF

--- a/doc/completion-nvim.txt
+++ b/doc/completion-nvim.txt
@@ -1,24 +1,25 @@
 *completion-nvim.txt*
-A async completion framework aims to provide completion to neovim's built in LSP written in Lua
+A async completion framework aims to provide completion to neovim's built in
+LSP written in Lua
 
 
-CONTENTS                                                            *completion-nvim*
+CONTENTS                                                     *completion-nvim*
 
     0. Introduction ......... |completion-introduction|
     1. Features ............. |completion-feature|
-    1. Prerequisite .......... |completion-prerequisite|
+    1. Prerequisite ......... |completion-prerequisite|
     2. Setup ................ |completion-setup|
     3. Options .............. |completion-option|
 
-===============================================================================================
-INTRODUCTION						                        *completion-introdction*
+==============================================================================
+INTRODUCTION					     *completion-introdction*
 
 completion-nvim is an auto completion framework that aims to provide a better
-completion experience with neovim's built-in LSP.  Other LSP functionality is not
-supported.
+completion experience with neovim's built-in LSP.  Other LSP functionality is
+not supported.
 
-===============================================================================================
-FEATURE                                                     *completion-features*
+==============================================================================
+FEATURE                                                  *completion-features*
 
 - Asynchronous completion using libuv api.
 - Automatically open hover windows when popupmenu is available.
@@ -27,24 +28,24 @@ FEATURE                                                     *completion-features
 - ins-complete method integration
 - Chain completion support inspired by vim-mucomplete
 
-==============================================================================================
-PREREQUISITES                                               *completion-prerequisites*
+==============================================================================
+PREREQUISITES                                       *completion-prerequisites*
 
 - Neovim 5.0
 - You should be setting up language server with the help of nvim-lsp
 
-===============================================================================================
+==============================================================================
 SETUP                                                       *completion-setup*
 
-- completion-nvim require several autocommand set up to work properly, you should
-  set it up using the `on_attach` function like this.
+- completion-nvim requires several autocommands set up to work properly, you
+  should set it up using the `on_attach` function like this.
   >
   lua require'nvim_lsp'.pyls.setup{on_attach=require'completion'.on_attach}
 
 - Change `pyls` to whichever language server you are using.
 
-- If you want completion-nvim to be set up for all buffers instead of only being
-  used when lsp is enabled, call the `on_attach` function directly:
+- If you want completion-nvim to be set up for all buffers instead of only
+  being used when lsp is enabled, call the `on_attach` function directly:
 >
     " Use completion-nvim in every buffer
     autocmd BufEnter * lua require'completion'.on_attach()
@@ -52,16 +53,16 @@ SETUP                                                       *completion-setup*
     Note: It's okay to set up completion-nvim without lsp. It will simply use
     another completion source instead(Ex: snippets).
 
-===============================================================================================
-OPTION                                                      *completion-option*
+==============================================================================
+OPTION                                                    *completion-option*
 
-g:completion_enable_auto_popup                  *g:completion_enable_auto_popup*
+g:completion_enable_auto_popup               *g:completion_enable_auto_popup*
 
-        This variable enable automatically popup window for completion. Set
-        this value to 0 if you don't want automatically popup window.
+	This variable enable automatically popup window for completion. Set
+	this value to 0 if you don't want automatically popup window.
 
-        If you disable auto popup menu, you can manually trigger completion by
-        mapping keys. For example: 
+	If you disable auto popup menu, you can manually trigger completion by
+	mapping keys. For example: 
 >
         " map <c-p> to manually trigger completion 
         inoremap <silent><expr> <c-p> completion#trigger_completion()
@@ -82,22 +83,22 @@ g:completion_enable_auto_popup                  *g:completion_enable_auto_popup*
 
         default value: 1
 
-g:completion_enable_snippet                     *g:completion_enable_snippet*
+g:completion_enable_snippet                      *g:completion_enable_snippet*
 
-        You can specify what snippet engines you want to use. Possible value
+        You can specify which snippet engines you want to use. Possible values
         are |UltiSnips| and |Neosnippet|.
 
-        Note: Snippets engine will not work without setting this variables.
+        Note: Snippet engines will not work without setting this variables.
 
         default value: v:null
 
-g:completion_confirm_key                        *g:completion_confirm_key*
+g:completion_confirm_key                            *g:completion_confirm_key*
 
-        You can specify what keys to use for confirm completion(which will
+        You can specify which keys to use for confirm completion(which will
         select the completion items and expand snippets if available).
 
-        Note: Make sure to use proper escape sequence to avoid parsing issue,
-        for example:
+	Note: Make sure to use a proper escape sequence to avoid parsing
+	issues, for example:
 >
         " Change confirm key to <C-y>
         let g:completion_confirm_key = "\<C-y>"
@@ -107,49 +108,50 @@ g:completion_confirm_key                        *g:completion_confirm_key*
 
 g:completion_confirm_key_rhs                    *g:completion_confirm_key_rhs*
 
-        If the confirm key have a fallback mapping, for example, using auto
-        pair plugins that map to "\<CR>", you can provide it like it in this
-        options. For example:
+	If the confirm key has a fallback mapping, for example, using auto
+	pair plugins that map to "\<CR>", you can provide it like it in this
+	options. For example:
 >
-        " Fallback for https://github.com/Raimondi/delimitMate expanding on enter
-        let g:completion_confirm_key_rhs = "\<Plug>delimitMateCR"
+	" Fallback for https://github.com/Raimondi/delimitMate expanding on
+	enter let g:completion_confirm_key_rhs = "\<Plug>delimitMateCR"
 <
-g:completion_enable_auto_hover                  *g:completion_enable_auto_hover*
+g:completion_enable_auto_hover                *g:completion_enable_auto_hover*
 
-        By default, completion-nvim will automatically open up hover window
-        when you navigate through the complete items(including basic
-        information of snippets). You can turn it off by specify this option
-        to zero.
-
-        default value: 1
-
-g:completion_enable_auto_signature              *g:completion_enable_auto_signature*
-
-        By default signature help opens automatically whenever it is availabe.
-        You can turn it off by specify this option to zero.
+	By default, completion-nvim will automatically open a hover window
+	when you navigate through the complete items(including basic
+	information of snippets). You can turn this off by setting this option
+	to zero.
 
         default value: 1
 
-g:completion_enable_auto_paren			*g:completion_enable_auto_paren*
+g:completion_enable_auto_signature        *g:completion_enable_auto_signature*
+
+	By default signature help opens automatically whenever it is availabe.
+	You can turn it off by setting this option to zero.
+
+        default value: 1
+
+g:completion_enable_auto_paren		      *g:completion_enable_auto_paren*
 
 	Enable the auto insert parenthesis feature. completion-nvim will
-	insert parenthesis when complete method or functions.
+	insert parenthesis when completing methods or functions.
 
 	default value: 0
 
-g:completion_max_items                          *g:completion_max_items*
+g:completion_max_items                                *g:completion_max_items*
 
-        You can set a number limit for the maximum completion items. For
-        example, if you just want at most 10 items in your popup menu, set is
-        option equals to 10.
+	You can set a number limit for the maximum completion items. For
+	example, if you just want at most 10 items in your popup menu, set is
+	option equal to 10.
 
         Note: this option only works for non ins-complete sources.
 
         default value: v:null
 
 
-g:completion_trigger_character                  *g:completion_trigger_character*
-        You can add or disable a trigger character that will trigger completion.
+g:completion_trigger_character                *g:completion_trigger_character*
+	You can add or disable a trigger character that will trigger
+	completion.
 
         For example, disable trigger character
 >
@@ -159,8 +161,8 @@ g:completion_trigger_character                  *g:completion_trigger_character*
 >
         let g:completion_trigger_character = ['.', '::']
 <
-        Use autocmd if you want different trigger character for different
-        lanugages.
+	Use an autocmd if you want a different trigger character for different
+	lanugages.
 >
         augroup CompleteionTriggerCharacter
             autocmd!
@@ -171,7 +173,7 @@ g:completion_trigger_character                  *g:completion_trigger_character*
 
         default value: ['.']
 
-g:completion_timer_cycle                        *g:completion_timer_cycle*
+g:completion_timer_cycle                            *g:completion_timer_cycle*
 
         completion-nvim uses a timer to control the rate of completion. Adjust
         the timer rate by setting this value.
@@ -180,13 +182,13 @@ g:completion_timer_cycle                        *g:completion_timer_cycle*
 
         default value: 80
 
-g:completion_chain_complete_list	     *g:completion_chain_complete_list*
+g:completion_chain_complete_list	    *g:completion_chain_complete_list*
 
-	completion-nvim has chain completion support inspired by vim-mucomplete.
-	In short, you can divide completion sources in group and having 
-	ins-completion method as backup completion.
+	completion-nvim has chain completion support inspired by
+	vim-mucomplete.  In short, you can divide completion sources in groups
+	and have an ins-completion method as backup completion.
 
-	You can specify different completion list for different filetype. By
+	You can specify different completion list for different filetypes. By
 	default, possible sources are 'lsp', 'snippet', 'path' and various
 	ins-complete sources. Specify 'mode' as your key for ins-complete
 	sources, 'complete_items' for other sources. For example:
@@ -206,10 +208,10 @@ g:completion_chain_complete_list	     *g:completion_chain_complete_list*
 	imap <c-j> <cmd>lua require'source'.prevCompletion()<CR>
 	imap <c-k> <cmd>lua require'source'.nextCompletion()<CR>
 <
-	Customizing your completion sources is easy, for non ins-complete
+	Customizing your completion sources is easy. For non ins-complete
 	items, you can choose to put them in the same source or separate them.
-	For example, if you want to separate lsp and snippet into two different
-	sources:
+	For example, if you want to separate lsp and snippet into two
+	different sources:
 >
 	let g:completion_chain_complete_list = {
 	    \'default' : [
@@ -238,8 +240,8 @@ g:completion_chain_complete_list	     *g:completion_chain_complete_list*
 	"thes": i_CTRL-X_CTRL-T
 	"user": i_CTRL-X_CTRL-U
 <
-	You can also specify different completion list for different filetype,
-	for example:
+	You can also specify different completion lists for different
+	filetypes, for example:
 
 >
 	let g:completion_chain_complete_list = {
@@ -258,10 +260,10 @@ g:completion_chain_complete_list	     *g:completion_chain_complete_list*
 	    \]
 	    \}
 <
-	You can take a step further to specified different 'scope' of different
-	filetype. 'scope' is literally syntax in your file. Say that you want
-	different completion list in comment and function call, string and etc,
-	you can have it done easily. Here is an example
+	You can take a step further to specify different 'scope' of different
+	filetypes. 'scope' is literally syntax in your file. Say that you want
+	different completion lists in comments and function calls, strings, 
+	etc, you can do that easily. Here is an example
 >
 	let g:completion_chain_complete_list = {
 	    \ 'lua': [
@@ -284,17 +286,17 @@ g:completion_chain_complete_list	     *g:completion_chain_complete_list*
 	    \   }
 	    \}
 <
-	Note: Every syntax highlighter have different syntax name defined(most
-	of them are similar though). You can check your syntax name under your
-	cursor by this command:
+	Note: Every syntax highlighter has a different syntax name
+	defined(most of them are similar though). You can check your syntax
+	name under your cursor by this command:
 >
 	:echo synIDattr(synID(line('.'), col('.'), 1), "name")
 <
-	You just need to specify a part of a result in the scope since it use
-	regex pattern to match it ( For example: if the result is 'luaComment' 
+	You just need to specify a part of a result in the scope since it uses
+	a regex pattern to match it ( For example: if the result is 'luaComment'
 	you only need to specified 'comment', case doesn't matter).
 
-g:completion_auto_change_source		*g:completion_auto_change_source*	
+g:completion_auto_change_source		     *g:completion_auto_change_source*
 
 	You can let completion-nvim changes source whenever current source has
 	no complete items by setting this option to 1.


### PR DESCRIPTION
Some of these are just grammar changes, and then some are ensuring that the vim docs are actually matching what you have set for text width etc.