### PR TITLE
Fix triggered_only bahavior and documentation

### DIFF
--- a/doc/completion-nvim.txt
+++ b/doc/completion-nvim.txt
@@ -233,6 +233,13 @@ g:completion_chain_complete_list	    *g:completion_chain_complete_list*
 	    \]
 	}
 <
+	There is a few completion source built in for now, here's a list.
+>
+	"lsp": lsp completion
+	"snippet": snippet sources based on g:completion_enable_snippet
+	"path": path completion relative to the current file.
+<
+
 	For ins-complete sources, possible 'mode' to the actual key in vim are
 	listed below.
 >
@@ -297,6 +304,22 @@ g:completion_chain_complete_list	    *g:completion_chain_complete_list*
 	    \   }
 	    \}
 <
+	For every completion source, you can specify `triggered_only` key.
+	This completion source will only trigger when this key is press. For
+	example
+>
+	let g:completion_chain_complete_list = {
+	    \ 'default' : {
+	    \   'default': [
+	    \       {'complete_items': ['lsp', 'snippet']},
+	    \	    {'complete_items': ['path'], 'triggered_only' = ['/']},
+	    \       {'mode': '<c-p>'},
+	    \       {'mode': '<c-n>'}],
+	    \   'comment': []
+	    \   }
+	    \}
+<
+
 	Note: Every syntax highlighter has a different syntax name
 	defined(most of them are similar though). You can check your syntax
 	name under your cursor by this command:

--- a/lua/source.lua
+++ b/lua/source.lua
@@ -84,8 +84,12 @@ local triggerCurrentCompletion = function(manager, bufnr, line_to_cursor, prefix
 
   -- handle user defined only triggered character
   if complete_source['triggered_only'] ~= nil then
-    triggered = util.checkTriggerCharacter(line_to_cursor, complete_source['triggered_only'])
-    if not triggered then return end
+    local triggered_only = util.checkTriggerCharacter(line_to_cursor, complete_source['triggered_only'])
+    if not triggered_only then
+      if manager.autoChange then
+        manager.changeSource = true
+      end
+    end
   end
 
   local length = vim.g.completion_trigger_keyword_length
@@ -139,7 +143,7 @@ function M.autoCompletion(manager)
   M.prefixLength = #prefix
 
   -- force reset chain completion if entering a new word
-  if (#prefix < length) and string.sub(line_to_cursor, #line_to_cursor, #line_to_cursor) == ' ' then
+  if (#prefix < length) then
     M.chain_complete_index = 1
     M.stop_complete = false
     manager.changeSource = false

--- a/lua/source.lua
+++ b/lua/source.lua
@@ -89,6 +89,7 @@ local triggerCurrentCompletion = function(manager, bufnr, line_to_cursor, prefix
       if manager.autoChange then
         manager.changeSource = true
       end
+      return
     end
   end
 


### PR DESCRIPTION
`triggered_only` is a key you can specify after every `chain_completion_list` to make it only triggered on those keys. This PR fix the behavior of triggered_only cause it break auto changing source now.

- [x] fix the behavior of triggered_only
- [x] documentation