### PR TITLE
feat(source): buffer(s) completion source

### DIFF
--- a/doc/completion-nvim.txt
+++ b/doc/completion-nvim.txt
@@ -200,7 +200,7 @@ g:completion_chain_complete_list	    *g:completion_chain_complete_list*
 	and have an ins-completion method as backup completion.
 
 	You can specify different completion list for different filetypes. By
-	default, possible sources are 'lsp', 'snippet', 'path' and various
+	default, possible sources are 'lsp', 'snippet', 'path', 'buffer', 'buffers' and various
 	ins-complete sources. Specify 'mode' as your key for ins-complete
 	sources, 'complete_items' for other sources. For example:
 >
@@ -238,6 +238,8 @@ g:completion_chain_complete_list	    *g:completion_chain_complete_list*
 	"lsp": lsp completion
 	"snippet": snippet sources based on g:completion_enable_snippet
 	"path": path completion relative to the current file.
+	"buffer": words in the current buffer
+	"buffers": words in all listed buffers
 <
 
 	For ins-complete sources, possible 'mode' to the actual key in vim are

--- a/lua/source.lua
+++ b/lua/source.lua
@@ -6,6 +6,7 @@ local chain_completion = require 'completion.chain_completion'
 local lsp = require 'source.lsp'
 local snippet = require 'source.snippet'
 local path = require 'source.path'
+local buffers = require 'source.buffers'
 
 local M = {}
 
@@ -23,6 +24,12 @@ local complete_items_map = {
     callback = path.getCallback,
     trigger = path.triggerFunction,
     trigger_character = {'/'}
+  },
+  ['buffers'] = {
+    item = buffers.getBuffersCompletionItems
+  },
+  ['buffer'] = {
+    item = buffers.getBufferCompletionItems
   },
 }
 

--- a/lua/source/buffers.lua
+++ b/lua/source/buffers.lua
@@ -1,0 +1,67 @@
+local M = {}
+local api = vim.api
+
+local function get_buf_var(bufnr, name, default)
+  local success, value = pcall(function() api.nvim_buf_get_var(bufnr, name) end)
+
+  return success and value or default
+end
+
+function M.get_words(bufnr, separator, min_length)
+  separator = separator or get_buf_var(bufnr, "completion_word_separator", "\\A")
+  min_length = min_length or get_buf_var(bufnr, "completion_word_min_length", 3)
+
+  local lines = api.nvim_buf_get_lines(bufnr, 0, -1, true)
+  local parts = vim.fn.split(vim.fn.join(lines), separator)
+  local words = {}
+
+  for _,part in ipairs(parts) do
+    if #part >= min_length and not words[part] then
+      words[part] = true
+    end
+  end
+
+  return words
+end
+
+function M.get_all_buffer_words(separator, min_length)
+  local bufs = vim.fn.getbufinfo({ buflisted = 1 })
+  local result = {}
+
+  for _,buf in ipairs(bufs) do
+    result = vim.tbl_extend("keep", M.get_words(buf.bufnr, separator, min_length), result)
+  end
+
+  return result
+end
+
+function M.get_completion_items(words, prefix, score_func, kind)
+  local complete_items = {}
+
+  for _,word in ipairs(words) do
+    local score = score_func(prefix, word)
+
+    if score < #prefix / 2 and word ~= prefix then
+      table.insert(complete_items, {
+        word = word;
+        kind = kind;
+        score = score;
+        icase = 1;
+        dup = 0;
+        empty = 0;
+      })
+    end
+  end
+
+  return complete_items
+end
+
+function M.getBuffersCompletionItems(prefix, score_func)
+  return M.get_completion_items(vim.tbl_keys(M.get_all_buffer_words()), prefix, score_func, "buffers")
+end
+
+function M.getBufferCompletionItems(prefix, score_func)
+  return M.get_completion_items(vim.tbl_keys(M.get_words(vim.fn.bufnr('.'))), prefix, score_func, "buffer")
+end
+
+return M


### PR DESCRIPTION
This adds a completion source for buffer words and words from buffers in the buffer list. Words can be configured per buffer by setting `completion_word_separator` and `completion_word_min_length`. This source offers two sources, one for words only in the current buffer and words from all buffers in the buffer list.