### PR TITLE
fix: confirm key should reset completion if no items selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,13 @@ let g:completion_confirm_key = "\<C-y>"
 
 - Make sure to use `" "` and add escape key `\` to avoid parsing issues.
 - If the confirm key has a fallback mapping, for example when using the auto
-  pairs plugin, it maps to `<CR>`. Provide it like this:
+  pairs plugin, it maps to `<CR>`. You can avoid using the default confirm key option and
+  use a mapping like this instead.
 
 ```.vim
-"Fallback for https://github.com/Raimondi/delimitMate expanding on enter
-let g:completion_confirm_key_rhs = "\<Plug>delimitMateCR"
+let g:completion_confirm_key = ""
+imap <expr> <cr>  pumvisible() ? complete_info()["selected"] != "-1" ?
+                 \ "\<Plug>(completion_confirm_completion)"  : "\<c-e>\<CR>" :  "\<CR>"
 ```
 
 ### Enable/Disable auto hover

--- a/autoload/completion.vim
+++ b/autoload/completion.vim
@@ -5,17 +5,12 @@ function! completion#completion_confirm() abort
 endfunction
 
 function! completion#wrap_completion() abort
-    if pumvisible() != 0
+    if pumvisible() != 0 && complete_info()["selected"] != "-1"
         call completion#completion_confirm()
     else
+        call nvim_feedkeys("\<c-g>\<c-g>", "n", v:true)
         let key = g:completion_confirm_key
-        let remap = 'n'
-        if !empty(g:completion_confirm_key_rhs)
-            let key = g:completion_confirm_key_rhs
-            let remap = 'm'
-        endif
-
-        call nvim_feedkeys(key, remap, v:true)
+        call nvim_feedkeys(key, "n", v:true)
     endif
 endfunction
 

--- a/doc/completion-nvim.txt
+++ b/doc/completion-nvim.txt
@@ -107,14 +107,14 @@ g:completion_confirm_key                            *g:completion_confirm_key*
 
         default value: "\<CR>"
 
-g:completion_confirm_key_rhs                    *g:completion_confirm_key_rhs*
-
-	If the confirm key has a fallback mapping, for example, using auto
-	pair plugins that map to "\<CR>", you can provide it like it in this
-	options. For example:
+	If the confirm key has a fallback mapping, for example when using the auto
+	pairs plugin, it maps to `<cr>`. you can avoid using the default confirm key
+	option and use a mapping like this instead.
 >
-	" Fallback for https://github.com/Raimondi/delimitMate expanding on
-	enter let g:completion_confirm_key_rhs = "\<Plug>delimitMateCR"
+	let g:completion_confirm_key = ""
+	imap <expr> <cr>  pumvisible() ? complete_info()["selected"] != "-1" ?
+			\ "\<Plug>(completion_confirm_completion)"  :
+			\ "\<c-e>\<CR>" : "\<CR>"
 <
 g:completion_enable_auto_hover                *g:completion_enable_auto_hover*
 


### PR DESCRIPTION
As title:)

- [x] Deprecated g:completion_confirm_key_rhs
- [x] fix the confirm key behavior
- [x] document the fallback mapping `<Plug>(completion_confirm_completion)`