### PR TITLE
Correct boolean interpretation for config variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ set shortmess+=c
 - By default auto popup is enabled, turn it off by
 
 ```vim
-let g:completion_enable_auto_popup = 0
+let g:completion_enable_auto_popup = v:false
 ```
 - Or you can toggle auto popup on the fly by using command `CompletionToggle`
 - You can manually trigger completion with mapping key by
@@ -164,7 +164,7 @@ imap <expr> <cr>  pumvisible() ? complete_info()["selected"] != "-1" ?
   called and displays in a floating window. Disable it by
 
 ```vim
-let g:completion_enable_auto_hover = 0
+let g:completion_enable_auto_hover = v:false
 ```
 
 ### Enable/Disable auto signature
@@ -173,7 +173,7 @@ let g:completion_enable_auto_hover = 0
   it by
 
 ```vim
-let g:completion_enable_auto_signature = 0
+let g:completion_enable_auto_signature = v:false
 ```
 
 ### Sorting completion items
@@ -251,7 +251,7 @@ let g:completion_trigger_keyword_length = 3 " default = 1
 you can enable it by
 
 ```vim
-let g:completion_trigger_on_delete = 1
+let g:completion_trigger_on_delete = v:true
 ```
 
 ### Timer Adjustment

--- a/lua/completion.lua
+++ b/lua/completion.lua
@@ -98,7 +98,7 @@ local function applyAddtionalTextEdits(completed_item)
   if completed_item.user_data.lsp ~= nil then
     local item = completed_item.user_data.lsp.completion_item
     -- vim-vsnip have better additional text edits...
-    if vim.fn.exists('g:loaded_vsnip_integ') then
+    if vim.fn.exists('g:loaded_vsnip_integ') ~= 0 then
       api.nvim_call_function('vsnip_integ#do_complete_done', {
         {
           completed_item = completed_item,

--- a/lua/completion.lua
+++ b/lua/completion.lua
@@ -98,7 +98,7 @@ local function applyAddtionalTextEdits(completed_item)
   if completed_item.user_data.lsp ~= nil then
     local item = completed_item.user_data.lsp.completion_item
     -- vim-vsnip have better additional text edits...
-    if vim.fn.exists('g:loaded_vsnip_integ') == 1 then
+    if vim.fn.exists('g:loaded_vsnip_integ') then
       api.nvim_call_function('vsnip_integ#do_complete_done', {
         {
           completed_item = completed_item,
@@ -129,7 +129,7 @@ local function hasConfirmedCompletion()
       require 'snippets'.expand_at_cursor(completed_item.user_data.actual_item, completed_item.word)
     end
   end
-  if opt.get_option('enable_auto_paren') == 1 then
+  if opt.get_option('enable_auto_paren') then
     autoAddParens(completed_item)
   end
   if completed_item.user_data.snippet_source == 'UltiSnips' then
@@ -174,7 +174,7 @@ function M.on_InsertEnter()
 
   -- TODO: remove this
   local autoChange = false
-  if opt.get_option('auto_change_source') == 1 then
+  if opt.get_option('auto_change_source') then
     autoChange = true
   end
 
@@ -189,13 +189,13 @@ function M.on_InsertEnter()
     -- complete if changes are made
     if l_changedTick ~= manager.changedTick then
       manager.changedTick = l_changedTick
-      if opt.get_option('enable_auto_popup') == 1 then
+      if opt.get_option('enable_auto_popup') then
         source.autoCompletion()
       end
-      if opt.get_option('enable_auto_hover') == 1 then
+      if opt.get_option('enable_auto_hover') then
         hover.autoOpenHoverInPopup(manager)
       end
-      if opt.get_option('enable_auto_signature') == 1 then
+      if opt.get_option('enable_auto_signature') then
         signature.autoOpenSignatureHelp()
       end
     end

--- a/lua/completion/matching.lua
+++ b/lua/completion/matching.lua
@@ -4,9 +4,9 @@ local opt = require 'completion.option'
 local M = {}
 
 local function setup_case(prefix, word)
-  local ignore_case = opt.get_option('matching_ignore_case') == 1
+  local ignore_case = opt.get_option('matching_ignore_case')
 
-  if ignore_case and opt.get_option('matching_smart_case') == 1 and prefix:match('[A-Z]') then
+  if ignore_case and opt.get_option('matching_smart_case') and prefix:match('[A-Z]') then
     ignore_case = false
   end
 

--- a/lua/completion/source.lua
+++ b/lua/completion/source.lua
@@ -87,7 +87,7 @@ local triggerCurrentCompletion = function(bufnr, line_to_cursor, prefix, textMat
           if value.server_capabilities.completionProvider == nil then
             break
           end
-          if opt.get_option('enable_server_trigger') == 1 then
+          if opt.get_option('enable_server_trigger') then
             triggered = triggered or util.checkTriggerCharacter(line_to_cursor,
               value.server_capabilities.completionProvider.triggerCharacters)
           end
@@ -101,7 +101,7 @@ local triggerCurrentCompletion = function(bufnr, line_to_cursor, prefix, textMat
   if complete_source['triggered_only'] ~= nil then
     local triggered_only = util.checkTriggerCharacter(line_to_cursor, complete_source['triggered_only'])
     if not triggered_only then
-      if opt.get_option('auto_change_source') == 1 then
+      if opt.get_option('auto_change_source') then
         manager.changeSource = true
       end
       return
@@ -164,7 +164,7 @@ function M.autoCompletion()
     -- not sure if I should clear cache here
     complete.clearCache()
     -- api.nvim_input("<c-g><c-g>")
-    if opt.get_option('trigger_on_delete') == 1 then
+    if opt.get_option('trigger_on_delete') then
       M.triggerCompletion(false)
     end
     M.stop_complete = false


### PR DESCRIPTION
Instead of comparing configuration values read from local config files
with integer values 1 or 0, use their boolean interpretation as they can
be directly set to v:true or v:false respectively in config files.

Solves #364 