### PR TITLE
feat(auto close brace)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,14 @@ let g:completion_enable_auto_hover = 0
 let g:completion_enable_auto_signature = 0
 ```
 
+### Enable/Disable auto close brace
+
+- By default variable completion with brace will not auto close. Enable it by
+
+```vim
+let g:completion_enable_auto_close_brace = 1
+```
+
 ### Sorting completion items
 
 - You can decide how your items being sorted in the popup menu. The default value

--- a/lua/completion.lua
+++ b/lua/completion.lua
@@ -84,6 +84,12 @@ local function autoAddParens(completed_item)
   end
 end
 
+local function autoAddBrace(completed_item)
+  if completed_item.kind == 'Variable' and string.match(completed_item.abbr, '.*}$') and string.match(completed_item.word, '.*}$') == nil then
+    api.nvim_input("}<left>")
+  end
+end
+
 -- Workaround to avoid expand snippets when not confirm
 -- confirmCompletion is now triggered by CompleteDone autocmd to solve issue with noselect
 -- Will cause snippets to expand with not pressing confirm key
@@ -132,6 +138,11 @@ local function hasConfirmedCompletion()
   if opt.get_option('enable_auto_paren') == 1 then
     autoAddParens(completed_item)
   end
+
+  if opt.get_option('enable_auto_close_brace') == 1 then
+    autoAddBrace(completed_item)
+  end
+
   if completed_item.user_data.snippet_source == 'UltiSnips' then
     api.nvim_call_function('UltiSnips#ExpandSnippet', {})
   elseif completed_item.user_data.snippet_source == 'Neosnippet' then

--- a/lua/completion.lua
+++ b/lua/completion.lua
@@ -134,11 +134,13 @@ local function hasConfirmedCompletion()
     if opt.get_option('enable_snippet') == "snippets.nvim" then
       require 'snippets'.expand_at_cursor(completed_item.user_data.actual_item, completed_item.word)
     end
-  elseif opt.get_option('enable_auto_close_brace') == 1 then
-    autoAddBrace(completed_item)
-  end
-  if opt.get_option('enable_auto_paren') == 1 then
-    autoAddParens(completed_item)
+  else
+    if opt.get_option('enable_auto_close_brace') == 1 then
+      autoAddBrace(completed_item)
+    end
+    if opt.get_option('enable_auto_paren') == 1 then
+      autoAddParens(completed_item)
+    end
   end
 
   if completed_item.user_data.snippet_source == 'UltiSnips' then

--- a/lua/completion.lua
+++ b/lua/completion.lua
@@ -134,13 +134,11 @@ local function hasConfirmedCompletion()
     if opt.get_option('enable_snippet') == "snippets.nvim" then
       require 'snippets'.expand_at_cursor(completed_item.user_data.actual_item, completed_item.word)
     end
+  elseif opt.get_option('enable_auto_close_brace') == 1 then
+    autoAddBrace(completed_item)
   end
   if opt.get_option('enable_auto_paren') == 1 then
     autoAddParens(completed_item)
-  end
-
-  if opt.get_option('enable_auto_close_brace') == 1 then
-    autoAddBrace(completed_item)
   end
 
   if completed_item.user_data.snippet_source == 'UltiSnips' then


### PR DESCRIPTION
I use gopls to complete some structs, but when the suggestion is a struct like `&model.User{}`, it will complete without closing the brace(`&model.User{`)

Enable auto close brace by

```vim
let g:completion_enable_auto_close_brace = 1
```
