### PR TITLE
Change handler signature

### DIFF
--- a/lua/completion/hover.lua
+++ b/lua/completion/hover.lua
@@ -258,8 +258,15 @@ local fancy_floating_markdown = function(contents, opts)
   return bufnr, winnr
 end
 
-local function handler_function(_, method, result)
+local function handler_function(_, ...)
   if vim.fn.pumvisible() == 1 then
+    local method = select(1, ...)
+    local result = select(2, ...)
+    if type(method) == 'table' then
+      result = select(1, ...)
+      method = select(2, ...).method
+    end
+
     M.focusable_float(method, function()
       if not (result and result.contents) then
         -- return { 'No information available' }

--- a/lua/completion/signature_help.lua
+++ b/lua/completion/signature_help.lua
@@ -29,11 +29,18 @@ M.autoOpenSignatureHelp = function()
     -- overwrite signature help here to disable "no signature help" message
     local params = vim.lsp.util.make_position_params()
     local filetype = vim.api.nvim_buf_get_option(0, 'filetype')
-    vim.lsp.buf_request(0, 'textDocument/signatureHelp', params, function(err, method, result, client_id)
+    vim.lsp.buf_request(0, 'textDocument/signatureHelp', params, function(...)
+      local result = select(3, ...)
+      local client_id = select(4, ...)
+      if type(select(2, ...)) == 'table' then
+        result = select(2, ...)
+        client_id = select(3, ...).client_id
+      end
+
       local client = vim.lsp.get_client_by_id(client_id)
       local handler = client and client.handlers['textDocument/signatureHelp']
       if handler then
-          handler(err, method, result, client_id)
+          handler(...)
           return
       end
       if not (result and result.signatures and result.signatures[1]) then

--- a/lua/completion/source/lsp.lua
+++ b/lua/completion/source/lsp.lua
@@ -146,7 +146,11 @@ M.triggerFunction = function(_, params)
     M.callback = true
     return
   end
-  vim.lsp.buf_request(params.bufnr, 'textDocument/completion', position_param, function(err, _, result)
+  vim.lsp.buf_request(params.bufnr, 'textDocument/completion', position_param, function(...)
+    local result = select(2, ...)
+    if type(result) == 'string' then
+      result = select(3, ...)
+    end
     if err or not result then
       M.callback = true
       return


### PR DESCRIPTION
Completion-nvim is broken for nvim >= 0.5.1
The signature changed from `function(err, method, result, client_id, bufnr, config)` to `function(err, result, ctx, config)`.

> ref; https://github.com/neovim/neovim/pull/15504